### PR TITLE
allow sub-categories to be listed

### DIFF
--- a/classes/item/CategoryItem.php
+++ b/classes/item/CategoryItem.php
@@ -127,7 +127,6 @@ class CategoryItem extends ElementItem
 
         //Get slug list
         $arSlugList = $this->getSlugList();
-        $arSlugList = array_reverse($arSlugList);
 
         //Prepare page property list
         $arPagePropertyList = [];


### PR DESCRIPTION
The removed line caused only the TOP categories to be listed (multiple times)