### PR TITLE
Add URL parameters support to getPageUrl()

### DIFF
--- a/classes/item/CategoryItem.php
+++ b/classes/item/CategoryItem.php
@@ -107,7 +107,7 @@ class CategoryItem extends ElementItem
      *
      * @return string
      */
-    public function getPageUrl($sPageCode = null, $arRemoveParamList = [])
+    public function getPageUrl($sPageCode = null, $arRemoveParamList = [], $arAddParamList = [])
     {
         if (empty($sPageCode)) {
             $sPageCode = Settings::getValue('default_category_page_id', 'catalog');
@@ -115,6 +115,10 @@ class CategoryItem extends ElementItem
 
         //Get URL params
         $arParamList = $this->getPageParamList($sPageCode, $arRemoveParamList);
+
+        if (!empty($arAddParamList)) {
+            $arParamList = array_merge($arParamList, $arAddParamList);
+        }
 
         //Generate page URL
         $sURL = CmsPage::url($sPageCode, $arParamList);

--- a/classes/item/ProductItem.php
+++ b/classes/item/ProductItem.php
@@ -140,7 +140,7 @@ class ProductItem extends ElementItem
      *
      * @return string
      */
-    public function getPageUrl($sPageCode = null, $arRemoveParamList = [])
+    public function getPageUrl($sPageCode = null, $arRemoveParamList = [], $arAddParamList = [])
     {
         if (empty($sPageCode)) {
             $sPageCode = Settings::getValue('default_product_page_id', 'product');
@@ -148,6 +148,10 @@ class ProductItem extends ElementItem
 
         //Get URL params
         $arParamList = $this->getPageParamList($sPageCode, $arRemoveParamList);
+
+        if (!empty($arAddParamList)) {
+            $arParamList = array_merge($arParamList, $arAddParamList);
+        }
 
         //Generate page URL
         $sURL = CmsPage::url($sPageCode, $arParamList);


### PR DESCRIPTION
This will allow generating a link if the CMS page has other parameters besides categories and product slug. For example `url = "/:vendor/products/:category*/:slug?"`