### PR TITLE
Fix CategoryList tree() method for OctoberCMS v2 with v1 compitability

### DIFF
--- a/classes/store/category/TopLevelListStore.php
+++ b/classes/store/category/TopLevelListStore.php
@@ -20,7 +20,7 @@ class TopLevelListStore extends AbstractStoreWithoutParam
     protected function getIDListFromDB() : array
     {
         $arElementIDList = (array) Category::active()
-            ->where('nest_depth', 0)
+            ->whereIn('nest_depth', [0, NULL])
             ->orderBy('nest_left', 'asc')
             ->lists('id');
 


### PR DESCRIPTION
In OCMS V2, nest_depth column no longer stores 0 for top level nodes.