### PR TITLE
Another fix for tree() method

### DIFF
--- a/classes/store/category/TopLevelListStore.php
+++ b/classes/store/category/TopLevelListStore.php
@@ -20,7 +20,7 @@ class TopLevelListStore extends AbstractStoreWithoutParam
     protected function getIDListFromDB() : array
     {
         $arElementIDList = (array) Category::active()
-            ->whereIn('nest_depth', [0, null])
+            ->whereNull('parent_id')
             ->orderBy('nest_left', 'asc')
             ->lists('id');
 


### PR DESCRIPTION
Looks like in some rare situations whereIn doesn't work with null value: https://laracasts.com/discuss/channels/eloquent/wherein-with-null

One of the users reported that whereIn doesn't work for him while ->whereNull('parent_id') does.

This commit changes where clause from nest_depth to parent_id which always stays null if record doesn't have any parent nodes in ocms v1 and v2.