### PR TITLE
Adds lovata/toolbox-plugin system requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "october-plugin",
     "description": "eCommerce plugin for October CMS",
     "require": {
+        "lovata/toolbox-plugin": "^1.0",
         "composer/installers": "~1.0"
     }
 }


### PR DESCRIPTION
For your consideration,

This plugin will crash the system without Toolbox plugin present. When running `php artisan plugin:install lovata.shopaholic` the dependencies are not installed because they are missing from the composer file.

```
Class 'Lovata\Toolbox\Classes\Event\ModelHandler' not found
```

We can overcome this by running `composer require lovata/toolbox-plugin` however this is difficult for the user to know without prior system knowledge.

The proposed change will ensure all dependencies are installed from the start and smooth delivery.

Thanks for your for attention!