### PR TITLE
Change standard relation dropdown lists with recordfinder

### DIFF
--- a/models/product/fields.yaml
+++ b/models/product/fields.yaml
@@ -34,7 +34,8 @@ tabs:
             nameFrom: name
             descriptionFrom: description
             span: left
-            type: relation
+            type: recordfinder
+            list: $/lovata/shopaholic/models/category/columns.yaml
             tab: 'lovata.toolbox::lang.tab.settings'
         additional_category:
             label: 'lovata.shopaholic::lang.field.additional_category'
@@ -48,7 +49,8 @@ tabs:
         brand:
             label: 'lovata.shopaholic::lang.field.brand'
             span: left
-            type: relation
+            type: recordfinder
+            list: $/lovata/shopaholic/models/brand/columns.yaml
             tab: 'lovata.toolbox::lang.tab.settings'
             emptyOption: 'lovata.toolbox::lang.field.empty'
         code:


### PR DESCRIPTION
If there are more than >1000 categories and same with brands, load times for Product create/edit page are insane. 
Recordfinder fixes this problem.