### PR TITLE
added product url/slug aliases/synonyms

### DIFF
--- a/components/ProductPage.php
+++ b/components/ProductPage.php
@@ -1,4 +1,6 @@
-<?php namespace Lovata\Shopaholic\Components;
+<?php
+
+namespace Lovata\Shopaholic\Components;
 
 use Event;
 use Lovata\Toolbox\Classes\Component\ElementPage;
@@ -59,11 +61,14 @@ class ProductPage extends ElementPage
 
         if ($this->isSlugTranslatable()) {
             $obElement = Product::active()->transWhere('slug', $sElementSlug)->first();
+            if (!$obElement) {
+                $obElement = Product::active()->transWhere('slug_alias', $sElementSlug)->first();
+            }
             if (!$this->checkTransSlug($obElement, $sElementSlug)) {
                 $obElement = null;
             }
         } else {
-            $obElement = Product::active()->getBySlug($sElementSlug)->first();
+            $obElement = Product::active()->where('slug', $sElementSlug)->orWhere('slug_alias', $sElementSlug)->first();
         }
         if (!empty($obElement)) {
             Event::fire('shopaholic.product.open', [$obElement]);

--- a/models/Product.php
+++ b/models/Product.php
@@ -30,6 +30,7 @@ use Lovata\Shopaholic\Classes\Import\ImportProductModelFromCSV;
  * @property bool                                                                                      $active
  * @property string                                                                                    $name
  * @property string                                                                                    $slug
+ * @property string                                                                                    $slug_alias
  * @property string                                                                                    $code
  * @property int                                                                                       $category_id
  * @property int                                                                                       $brand_id
@@ -152,14 +153,19 @@ class Product extends ImportModel
     public $rules = [
         'name' => 'required',
         'slug' => 'required|unique:lovata_shopaholic_products',
+        'slug_alias' => 'required|unique:lovata_shopaholic_products',
     ];
 
     public $attributeNames = [
         'name' => 'lovata.toolbox::lang.field.name',
         'slug' => 'lovata.toolbox::lang.field.slug',
+        'slug_alias' => 'lovata.toolbox::lang.field.slug_alias',
     ];
 
-    public $slugs = ['slug' => 'name'];
+    public $slugs = [
+        'slug' => 'name',
+        'slug_alias' => ''
+    ];
 
     public $attachOne = [
         'preview_image' => 'System\Models\File',
@@ -192,6 +198,7 @@ class Product extends ImportModel
         'active',
         'name',
         'slug',
+        'slug_alias',
         'code',
         'external_id',
         'preview_text',
@@ -205,6 +212,7 @@ class Product extends ImportModel
         'active',
         'name',
         'slug',
+        'slug_alias',
         'code',
         'category_id',
         'brand_id',

--- a/models/product/fields.yaml
+++ b/models/product/fields.yaml
@@ -36,6 +36,14 @@ tabs:
             span: left
             type: relation
             tab: 'lovata.toolbox::lang.tab.settings'
+        slug_alias:
+            label: 'lovata.toolbox::lang.field.slug_alias'
+            span: right
+            preset:
+                field: name
+                type: slug
+            type: text
+            tab: 'lovata.toolbox::lang.tab.settings'
         additional_category:
             label: 'lovata.shopaholic::lang.field.additional_category'
             type: relation

--- a/updates/update_table_products_add_slug_alias_field.php
+++ b/updates/update_table_products_add_slug_alias_field.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Lovata\Shopaholic\Updates;
+
+use Schema;
+use October\Rain\Database\Schema\Blueprint;
+use October\Rain\Database\Updates\Migration;
+
+/**
+ * Class UpdateTableProductsAddSlugAliasField
+ * @package Lovata\Shopaholic\Updates
+ */
+class UpdateTableProductsAddSlugAliasField extends Migration
+{
+    const TABLE_NAME = 'lovata_shopaholic_products';
+
+    /**
+     * Apply migration
+     */
+    public function up()
+    {
+        if (!Schema::hasTable(self::TABLE_NAME) || Schema::hasColumn(self::TABLE_NAME, 'slug_alias')) {
+            return;
+        }
+
+        Schema::table(self::TABLE_NAME, function (Blueprint $obTable) {
+            $obTable->string('slug_alias')->unique()->nullable();
+        });
+    }
+
+    /**
+     * Rollback migration
+     */
+    public function down()
+    {
+        if (!Schema::hasTable(self::TABLE_NAME) || !Schema::hasColumn(self::TABLE_NAME, 'slug_alias')) {
+            return;
+        }
+
+        Schema::table(self::TABLE_NAME, function (Blueprint $obTable) {
+            $obTable->dropColumn(['slug_alias']);
+        });
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -140,3 +140,6 @@
     - 'Fixed bug with category tree in v2. Fixed bug in BrandCollection class. Added lovata/toolbox-plugin package in composer.json file.'
 1.30.4:
     - 'Small fix. Thanks for contribution Igor Tverdokhleb.'
+1.30.5:
+    - 'Add slug alias/synonym field to help with redirecting and product slug changes.'
+    - update_table_products_add_slug_alias_field.php


### PR DESCRIPTION
This PR introduces a new field `slug_alias` which is an alternative `slug` or `url` that loads up the related product page!